### PR TITLE
Return XML as 'xml_document' 'xml_node'

### DIFF
--- a/R/api_get_provenance_metadata.R
+++ b/R/api_get_provenance_metadata.R
@@ -15,7 +15,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') EML metadata.
+#'     ("xml_document" "xml_node") EML metadata.
 #'     
 #'
 #' @export
@@ -35,12 +35,10 @@ api_get_provenance_metadata <- function(package.id, environment = 'production'){
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_list_data_descendants.R
+++ b/R/api_list_data_descendants.R
@@ -16,7 +16,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') XML containing the the 
+#'     ("xml_document" "xml_node") XML containing the the 
 #'     data package ID, data package title, and data package URL.
 #'
 #' @export
@@ -36,12 +36,10 @@ api_list_data_descendants <- function(package.id, environment = 'production'){
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
 
   output

--- a/R/api_list_data_package_citations.R
+++ b/R/api_list_data_package_citations.R
@@ -35,12 +35,10 @@ api_list_data_package_citations <- function(package.id, environment = 'productio
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_list_data_sources.R
+++ b/R/api_list_data_sources.R
@@ -14,7 +14,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') For each data source, its 
+#'     ('xml_document' 'xml_node') For each data source, its 
 #'     package identifier, title, and URL values are included (if applicable) 
 #'     as documented in the metadata for the specified data package. Internal 
 #'     data sources include a “packageId” value and a URL to the source 
@@ -38,12 +38,10 @@ api_list_data_sources <- function(package.id, environment = 'production'){
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_list_principal_owner_citations.R
+++ b/R/api_list_principal_owner_citations.R
@@ -13,7 +13,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') journalCitations metadata
+#'     ('xml_document' 'xml_node') journalCitations metadata
 #'
 #' @export
 #'
@@ -32,12 +32,10 @@ api_list_principal_owner_citations <- function(dn, environment = 'production'){
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_list_recent_changes.R
+++ b/R/api_list_recent_changes.R
@@ -28,7 +28,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') dataPackageChanges 
+#'     ('xml_document' 'xml_node') dataPackageChanges 
 #'     metadata.
 #'
 #' @export
@@ -71,12 +71,10 @@ api_list_recent_changes <- function(from.date = NULL, to.date = NULL, scope = NU
     
   }
 
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_list_recent_uploads.R
+++ b/R/api_list_recent_uploads.R
@@ -16,7 +16,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') dataPackageUploads 
+#'     ('xml_document' 'xml_node') dataPackageUploads 
 #'     metadata.
 #'
 #' @export
@@ -39,12 +39,10 @@ api_list_recent_uploads <- function(type, limit = 5, environment = 'production')
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_list_working_on.R
+++ b/R/api_list_working_on.R
@@ -12,7 +12,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') workingOn metadata
+#'     ('xml_document' 'xml_node') workingOn metadata
 #'
 #' @export
 #'
@@ -30,12 +30,10 @@ api_list_working_on <- function(environment = 'production'){
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_read_data_entity_resource_metadata.R
+++ b/R/api_read_data_entity_resource_metadata.R
@@ -19,7 +19,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') An XML string representing 
+#'     ('xml_document' 'xml_node') An XML string representing 
 #'     the resource metadata for the data entity.
 #'
 #' @export
@@ -49,12 +49,10 @@ api_read_data_entity_resource_metadata <- function(package.id, entity.id,
     )
   )
   
-  metadata <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  metadata <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   metadata

--- a/R/api_read_data_package_report.R
+++ b/R/api_read_data_package_report.R
@@ -15,7 +15,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') Data package report.
+#'     ('xml_document' 'xml_node') Data package report.
 #'     
 #'
 #' @export
@@ -35,12 +35,10 @@ api_read_data_package_report <- function(package.id, environment = 'production')
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_read_data_package_report_resource_metadata.R
+++ b/R/api_read_data_package_report_resource_metadata.R
@@ -16,7 +16,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') The resource metadata for 
+#'     ('xml_document' 'xml_node') The resource metadata for 
 #'     the data package report resource.
 #'     
 #'
@@ -37,12 +37,10 @@ api_read_data_package_report_resource_metadata <- function(package.id, environme
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_read_data_package_resource_metadata.R
+++ b/R/api_read_data_package_resource_metadata.R
@@ -15,7 +15,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') The resource metadata for 
+#'     ('xml_document' 'xml_node') The resource metadata for 
 #'     the data package.
 #'
 #' @export
@@ -35,12 +35,10 @@ api_read_data_package_resource_metadata <- function(package.id, environment = 'p
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_read_metadata.R
+++ b/R/api_read_metadata.R
@@ -14,7 +14,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') EML metadata.
+#'     ('xml_document' 'xml_node') EML metadata.
 #'     
 #'
 #' @export
@@ -34,12 +34,10 @@ api_read_metadata <- function(package.id, environment = 'production'){
     )
   )
   
-  eml <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  eml <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   eml

--- a/R/api_read_metadata_dublin_core.R
+++ b/R/api_read_metadata_dublin_core.R
@@ -14,7 +14,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') Dublin Core metadata
+#'     ('xml_document' 'xml_node') Dublin Core metadata
 #'     
 #'
 #' @export
@@ -34,12 +34,10 @@ api_read_metadata_dublin_core <- function(package.id, environment = 'production'
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/R/api_read_metadata_resource_metadata.R
+++ b/R/api_read_metadata_resource_metadata.R
@@ -15,7 +15,7 @@
 #'     Can be: 'development', 'staging', 'production'.
 #'
 #' @return
-#'     ('XMLInternalDocument' 'XMLAbstractDocument') An XML string representing 
+#'     ('xml_document' 'xml_node') An XML string representing 
 #'     the resource metadata for the data package metadata resource.
 #'     
 #'
@@ -36,12 +36,10 @@ api_read_metadata_resource_metadata <- function(package.id, environment = 'produ
     )
   )
   
-  output <- XML::xmlParse(
-    httr::content(
-      r,
-      as = 'parsed',
-      encoding = 'UTF-8'
-    )
+  output <- httr::content(
+    r,
+    as = 'parsed',
+    encoding = 'UTF-8'
   )
   
   output

--- a/man/api_get_provenance_metadata.Rd
+++ b/man/api_get_provenance_metadata.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') EML metadata.
+("xml_document" "xml_node") EML metadata.
 }
 \description{
 Add Provenance Metadata from Level-1 metadata in PASTA to an XML 

--- a/man/api_list_data_descendants.Rd
+++ b/man/api_list_data_descendants.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') XML containing the the 
+("xml_document" "xml_node") XML containing the the 
     data package ID, data package title, and data package URL.
 }
 \description{

--- a/man/api_list_data_sources.Rd
+++ b/man/api_list_data_sources.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') For each data source, its 
+('xml_document' 'xml_node') For each data source, its 
     package identifier, title, and URL values are included (if applicable) 
     as documented in the metadata for the specified data package. Internal 
     data sources include a “packageId” value and a URL to the source 

--- a/man/api_list_principal_owner_citations.Rd
+++ b/man/api_list_principal_owner_citations.Rd
@@ -14,7 +14,7 @@ api_list_principal_owner_citations(dn, environment = 'production')
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') journalCitations metadata
+('xml_document' 'xml_node') journalCitations metadata
 }
 \description{
 List Principal Owner Citations operation.

--- a/man/api_list_recent_changes.Rd
+++ b/man/api_list_recent_changes.Rd
@@ -18,7 +18,7 @@ api_list_recent_changes(from.date = NULL, to.date = NULL, scope = NULL,
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') dataPackageChanges 
+('xml_document' 'xml_node') dataPackageChanges 
     metadata.
 }
 \description{

--- a/man/api_list_recent_uploads.Rd
+++ b/man/api_list_recent_uploads.Rd
@@ -15,7 +15,7 @@ api_list_recent_uploads(type, limit = 5, environment = 'production')
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') dataPackageUploads 
+('xml_document' 'xml_node') dataPackageUploads 
     metadata.
 }
 \description{

--- a/man/api_list_working_on.Rd
+++ b/man/api_list_working_on.Rd
@@ -11,7 +11,7 @@ api_list_working_on(environment = 'production')
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') workingOn metadata
+('xml_document' 'xml_node') workingOn metadata
 }
 \description{
 List Working On operation, lists the set of data packages that PASTA is 

--- a/man/api_read_data_entity_resource_metadata.Rd
+++ b/man/api_read_data_entity_resource_metadata.Rd
@@ -18,7 +18,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') An XML string representing 
+('xml_document' 'xml_node') An XML string representing 
     the resource metadata for the data entity.
 }
 \description{

--- a/man/api_read_data_package_report.Rd
+++ b/man/api_read_data_package_report.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') Data package report.
+('xml_document' 'xml_node') Data package report.
 }
 \description{
 Read Data Package Report operation, specifying the scope, identifier, 

--- a/man/api_read_data_package_report_resource_metadata.Rd
+++ b/man/api_read_data_package_report_resource_metadata.Rd
@@ -16,7 +16,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') The resource metadata for 
+('xml_document' 'xml_node') The resource metadata for 
     the data package report resource.
 }
 \description{

--- a/man/api_read_data_package_resource_metadata.Rd
+++ b/man/api_read_data_package_resource_metadata.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') The resource metadata for 
+('xml_document' 'xml_node') The resource metadata for 
     the data package.
 }
 \description{

--- a/man/api_read_metadata.Rd
+++ b/man/api_read_metadata.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') EML metadata.
+('xml_document' 'xml_node') EML metadata.
 }
 \description{
 Read Metadata (EML) operation, specifying the scope, identifier, and 

--- a/man/api_read_metadata_dublin_core.Rd
+++ b/man/api_read_metadata_dublin_core.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') Dublin Core metadata
+('xml_document' 'xml_node') Dublin Core metadata
 }
 \description{
 Read Metadata (Dublin Core) operation, specifying the scope, identifier, 

--- a/man/api_read_metadata_resource_metadata.Rd
+++ b/man/api_read_metadata_resource_metadata.Rd
@@ -14,7 +14,7 @@ revision (e.g. 'edi.101.1').}
 Can be: 'development', 'staging', 'production'.}
 }
 \value{
-('XMLInternalDocument' 'XMLAbstractDocument') An XML string representing 
+('xml_document' 'xml_node') An XML string representing 
     the resource metadata for the data package metadata resource.
 }
 \description{

--- a/tests/testthat/test_api_get_provenance_metadata.R
+++ b/tests/testthat/test_api_get_provenance_metadata.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_data_descendants.R
+++ b/tests/testthat/test_api_list_data_descendants.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_data_package_citations.R
+++ b/tests/testthat/test_api_list_data_package_citations.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_data_sources.R
+++ b/tests/testthat/test_api_list_data_sources.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_principal_owner_citations.R
+++ b/tests/testthat/test_api_list_principal_owner_citations.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_recent_changes.R
+++ b/tests/testthat/test_api_list_recent_changes.R
@@ -11,7 +11,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
   expect_equal(
@@ -23,7 +23,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_recent_uploads.R
+++ b/tests/testthat/test_api_list_recent_uploads.R
@@ -11,7 +11,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_list_working_on.R
+++ b/tests/testthat/test_api_list_working_on.R
@@ -9,7 +9,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_data_entity_resource_metadata.R
+++ b/tests/testthat/test_api_read_data_entity_resource_metadata.R
@@ -11,7 +11,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_data_package_report.R
+++ b/tests/testthat/test_api_read_data_package_report.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_data_package_report_resource_metadata.R
+++ b/tests/testthat/test_api_read_data_package_report_resource_metadata.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_data_package_resource_metadata.R
+++ b/tests/testthat/test_api_read_data_package_resource_metadata.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_metadata.R
+++ b/tests/testthat/test_api_read_metadata.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_metadata_resource_metadata.R
+++ b/tests/testthat/test_api_read_metadata_resource_metadata.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })

--- a/tests/testthat/test_api_read_metdata_dublin_core.R
+++ b/tests/testthat/test_api_read_metdata_dublin_core.R
@@ -10,7 +10,7 @@ testthat::test_that('Test for object attributes', {
         environment = 'production'
       )
     ),
-    c('XMLInternalDocument', 'XMLAbstractDocument')
+    c('xml_document', 'xml_node')
   )
   
 })


### PR DESCRIPTION
This practice aligns better with the xml2 library, which is widely adopted in our domain of practice.